### PR TITLE
fix: Incompatibilidade com IPV6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
                 ports:
                         - 8009:8009
                         - 8080:8080
+				environment: 
+                        - "JAVA_OPTS=-Djava.net.preferIPv4Stack=true"
         forpdi-frontend:
                 build: ./frontend-web
                 image: platfor-front


### PR DESCRIPTION
O erro tinha algo relacionado ao undertow com docker, e o suporte a IPV6 de alguns S.O.s . 
Ao verificar erro similar em [https://github.com/jboss-dockerfiles/jbpm/issues/26](https://github.com/jboss-dockerfiles/jbpm/issues/26), e em [https://github.com/jboss-dockerfiles/jbpm/issues/15](https://github.com/jboss-dockerfiles/jbpm/issues/15)
Foi passado o argumento `-Djava.net.preferIPv4Stack=true` para JVM e funcionou.